### PR TITLE
bump dependency versions to be compatible with flutte 1.12.x

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: gsheet_to_arb
-version: 0.0.7
+version: 0.0.8
 author: Marcin Marek Gocał <marcin.gocal@gmail.com>
 description: Imports Application Resource Bundle (ARB) from Google Sheets documents
 
@@ -9,16 +9,16 @@ environment:
   sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
-  analyzer: ^0.36.3
+  analyzer: '>=0.36.0 <0.39.0'
   args: '>=0.12.1 <2.0.0'
   dart_style: ^1.0.0
-  intl: '>=0.15.3 <0.16.0'
+  intl: '>=0.15.3 <0.17.0'
   path: '>=0.9.0 <2.0.0'
   googleapis_auth: ^0.2.6
   googleapis: ^0.53.0
   code_builder: ^3.1.3
-  intl_translation: ^0.17.2
-  json_annotation: ^2.0.0
+  intl_translation: ^0.17.7
+  json_annotation: ^3.0.1
   file_utils: ^0.1.1
   logging: ^0.11.3+2
   recase: ^2.0.0+1
@@ -26,4 +26,4 @@ dependencies:
 dev_dependencies:
   test: ^1.5.3
   build_runner: ^1.0.0
-  json_serializable: ^2.0.0
+  json_serializable: ^3.2.3


### PR DESCRIPTION
This change makes this package compatible with the latest stable flutter version, as well as the latest intl version.