### PR TITLE
Add ability to configure Sheet columns and rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@
             category_prefix: "# " 
             document_id: 'TODO'
             sheet_id: '0'
+            columns: # This is an optional setting, if unused will fallback to default values
+                key: 0 # The column where the key for the translation is, defaults to 0
+                description: 1 # The column where the description is, defaults to 1
+                first_language_key: 2 # The first column for the language copy, assumes that all other columns after this one also contains a language translation, defaults to 2
+            rows: # This is an optional setting, if unused will fallback to default values
+                header_row: 0 # The header row containing the title for each column, such as language codes, defaults to 0
+                first_translation_row: 1 # The first row containing transaltions that should be parsed, assumes that all rows after this one also should be parsed, defaults 1
     ```
 
 5. Update gsheet authentication configuration created in ```gsheet_to_arb.yaml```

--- a/lib/src/config/plugin_config.dart
+++ b/lib/src/config/plugin_config.dart
@@ -78,16 +78,94 @@ class GoogleSheetConfig {
   @JsonKey(name: 'auth_file')
   String authFile;
 
+  @JsonKey(name: 'columns', fromJson: SheetColumns.generateFromJson)
+  SheetColumns sheetColumns;
+
+  @JsonKey(name: 'rows', fromJson: SheetRows.generateFromJson)
+  SheetRows sheetRows;
+
   @JsonKey(ignore: true)
   AuthConfig auth;
 
   GoogleSheetConfig(
-      {this.authFile, this.documentId, this.sheetId, this.categoryPrefix});
+      {this.authFile, this.documentId, this.sheetId, this.categoryPrefix, this.sheetColumns, this.sheetRows});
 
   factory GoogleSheetConfig.fromJson(Map<String, dynamic> json) =>
       _$GoogleSheetConfigFromJson(json);
 
   Map<String, dynamic> toJson() => _$GoogleSheetConfigToJson(this);
+
+
+}
+
+class DefaultSheetColumns {
+  static const int key = 0;
+  static const int description = 1;
+  static const int first_language_key = 2;
+}
+
+@JsonSerializable()
+class SheetColumns {
+  @JsonKey(name: 'key', defaultValue: DefaultSheetColumns.key)
+  final int key;
+
+  @JsonKey(name: 'description', defaultValue: DefaultSheetColumns.description)
+  final int description;
+
+  @JsonKey(name: 'first_language_key', defaultValue: DefaultSheetColumns.first_language_key)
+  final int first_language_key;
+
+  SheetColumns({
+    this.key = DefaultSheetColumns.key,
+    this.description = DefaultSheetColumns.description,
+    this.first_language_key = DefaultSheetColumns.first_language_key,
+  });
+
+  static SheetColumns generateFromJson(json) {
+    if(json == null) {
+      return SheetColumns();
+    }
+    return SheetColumns.fromJson(Map<String, dynamic>.from(json));
+  }
+
+  factory SheetColumns.fromJson(Map<String, dynamic> json) {
+    
+    return _$SheetColumnsFromJson(json);
+  }
+
+  Map<String, dynamic> toJson() => _$SheetColumnsToJson(this);
+}
+
+class DefaultSheetRows {
+  static const int header_row = 0;
+  static const int first_translation_row = 1;
+}
+
+@JsonSerializable()
+class SheetRows {
+  @JsonKey(name: 'header_row', defaultValue: DefaultSheetRows.header_row)
+  final int header_row;
+
+  @JsonKey(name: 'first_translation_row', defaultValue: DefaultSheetRows.first_translation_row)
+  final int first_translation_row;
+
+  SheetRows({
+    this.header_row = DefaultSheetRows.header_row,
+    this.first_translation_row = DefaultSheetRows.first_translation_row,
+  });
+
+  static SheetRows generateFromJson(json) {
+    if(json == null) {
+      return SheetRows();
+    }
+    return SheetRows.fromJson(Map<String, dynamic>.from(json));
+  }
+
+
+  factory SheetRows.fromJson(Map<String, dynamic> json) =>
+      _$SheetRowsFromJson(json);
+
+  Map<String, dynamic> toJson() => _$SheetRowsToJson(this);
 }
 
 ///

--- a/lib/src/config/plugin_config.g.dart
+++ b/lib/src/config/plugin_config.g.dart
@@ -49,6 +49,8 @@ GoogleSheetConfig _$GoogleSheetConfigFromJson(Map<String, dynamic> json) {
     documentId: json['document_id'] as String,
     sheetId: json['sheet_id'] as String,
     categoryPrefix: json['category_prefix'] as String,
+    sheetColumns: SheetColumns.generateFromJson(json['columns']),
+    sheetRows: SheetRows.generateFromJson(json['rows']),
   );
 }
 
@@ -58,6 +60,35 @@ Map<String, dynamic> _$GoogleSheetConfigToJson(GoogleSheetConfig instance) =>
       'sheet_id': instance.sheetId,
       'category_prefix': instance.categoryPrefix,
       'auth_file': instance.authFile,
+      'columns': instance.sheetColumns,
+      'rows': instance.sheetRows,
+    };
+
+SheetColumns _$SheetColumnsFromJson(Map<String, dynamic> json) {
+  return SheetColumns(
+    key: json['key'] as int ?? 0,
+    description: json['description'] as int ?? 1,
+    first_language_key: json['first_language_key'] as int ?? 2,
+  );
+}
+
+Map<String, dynamic> _$SheetColumnsToJson(SheetColumns instance) =>
+    <String, dynamic>{
+      'key': instance.key,
+      'description': instance.description,
+      'first_language_key': instance.first_language_key,
+    };
+
+SheetRows _$SheetRowsFromJson(Map<String, dynamic> json) {
+  return SheetRows(
+    header_row: json['header_row'] as int ?? 0,
+    first_translation_row: json['first_translation_row'] as int ?? 1,
+  );
+}
+
+Map<String, dynamic> _$SheetRowsToJson(SheetRows instance) => <String, dynamic>{
+      'header_row': instance.header_row,
+      'first_translation_row': instance.first_translation_row,
     };
 
 AuthConfig _$AuthConfigFromJson(Map<String, dynamic> json) {

--- a/lib/src/config/plugin_config_manager.dart
+++ b/lib/src/config/plugin_config_manager.dart
@@ -51,7 +51,11 @@ class PluginConfigManager {
               categoryPrefix: '# ',
               sheetId: '0',
               documentId: '<ADD_DOCUMENT_ID_HERE>',
-              authFile: './' + authFileName));
+              authFile: './' + authFileName,
+              sheetColumns: SheetColumns(),
+              sheetRows: SheetRows(),
+          ),
+        );
 
       final root = PluginConfigRoot(config).toJson();
       final yamlString = '\n' + YamlUtils.toYamlString(root);

--- a/lib/src/gsheet/ghseet_importer.dart
+++ b/lib/src/gsheet/ghseet_importer.dart
@@ -5,22 +5,36 @@ import 'package:gsheet_to_arb/src/translation_document.dart';
 import 'package:googleapis/sheets/v4.dart';
 import 'package:googleapis_auth/auth_io.dart';
 
-class _SheetColumns {
-  static int key = 0;
-  static int description = 1;
-  static int first_language_key = 2;
+class SheetColumns {
+  final int key;
+  final int description;
+  final int first_language_key;
+
+  SheetColumns({
+    this.key = 0,
+    this.description = 1,
+    this.first_language_key = 2,
+  });
 }
 
-class _SheetRows {
-  static int header_row = 0;
-  static int first_translation_row = 1;
+class SheetRows {
+  final int header_row;
+  final int first_translation_row;
+
+  SheetRows({
+    this.header_row = 0,
+    this.first_translation_row = 1,
+  });
 }
 
 class GSheetImporter {
   final AuthConfig auth;
   final String categoryPrefix;
+  final SheetColumns sheetColumns;
+  final SheetRows sheetRows;
+  
 
-  GSheetImporter({this.auth, this.categoryPrefix});
+  GSheetImporter({this.auth, this.categoryPrefix, this.sheetColumns, this.sheetRows});
 
   Future<TranslationsDocument> import(String documentId) async {
     Log.i('Importing ARB from Google sheet...');
@@ -74,8 +88,8 @@ class GSheetImporter {
     final languages = <String>[];
     final items = <TranslationRow>[];
 
-    var firstLanguageColumn = _SheetColumns.first_language_key;
-    var firstTranslationsRow = _SheetRows.first_translation_row;
+    var firstLanguageColumn = sheetColumns.first_language_key;
+    var firstTranslationsRow = sheetRows.first_translation_row;
 
     var currentCategory = '';
 
@@ -90,7 +104,7 @@ class GSheetImporter {
     for (var i = firstTranslationsRow; i < rows.length; i++) {
       var row = rows[i];
       var languages = row.values;
-      var key = languages[_SheetColumns.key].formattedValue;
+      var key = languages[sheetColumns.key].formattedValue;
 
       //Skip if empty row is found
       if (key == null) {
@@ -103,7 +117,7 @@ class GSheetImporter {
       }
 
       final description =
-          languages[_SheetColumns.description].formattedValue ?? '';
+          languages[sheetColumns.description].formattedValue ?? '';
 
       final values = row.values
           .sublist(firstLanguageColumn, row.values.length)

--- a/lib/src/gsheet/ghseet_importer.dart
+++ b/lib/src/gsheet/ghseet_importer.dart
@@ -5,40 +5,15 @@ import 'package:gsheet_to_arb/src/translation_document.dart';
 import 'package:googleapis/sheets/v4.dart';
 import 'package:googleapis_auth/auth_io.dart';
 
-class SheetColumns {
-  final int key;
-  final int description;
-  final int first_language_key;
-
-  SheetColumns({
-    this.key = 0,
-    this.description = 1,
-    this.first_language_key = 2,
-  });
-}
-
-class SheetRows {
-  final int header_row;
-  final int first_translation_row;
-
-  SheetRows({
-    this.header_row = 0,
-    this.first_translation_row = 1,
-  });
-}
-
 class GSheetImporter {
-  final AuthConfig auth;
-  final String categoryPrefix;
-  final SheetColumns sheetColumns;
-  final SheetRows sheetRows;
+  final GoogleSheetConfig config;
   
 
-  GSheetImporter({this.auth, this.categoryPrefix, this.sheetColumns, this.sheetRows});
+  GSheetImporter({this.config});
 
   Future<TranslationsDocument> import(String documentId) async {
     Log.i('Importing ARB from Google sheet...');
-    var authClient = await _getAuthClient(auth);
+    var authClient = await _getAuthClient(config.auth);
     Log.startTimeTracking();
     var sheetsApi = SheetsApi(authClient);
     var spreadsheet =
@@ -88,8 +63,8 @@ class GSheetImporter {
     final languages = <String>[];
     final items = <TranslationRow>[];
 
-    var firstLanguageColumn = sheetColumns.first_language_key;
-    var firstTranslationsRow = sheetRows.first_translation_row;
+    var firstLanguageColumn = config.sheetColumns.first_language_key;
+    var firstTranslationsRow = config.sheetRows.first_translation_row;
 
     var currentCategory = '';
 
@@ -104,20 +79,20 @@ class GSheetImporter {
     for (var i = firstTranslationsRow; i < rows.length; i++) {
       var row = rows[i];
       var languages = row.values;
-      var key = languages[sheetColumns.key].formattedValue;
+      var key = languages[config.sheetColumns.key].formattedValue;
 
       //Skip if empty row is found
       if (key == null) {
         continue;
       }
 
-      if (key.startsWith(categoryPrefix)) {
-        currentCategory = key.substring(categoryPrefix.length);
+      if (key.startsWith(config.categoryPrefix)) {
+        currentCategory = key.substring(config.categoryPrefix.length);
         continue;
       }
 
       final description =
-          languages[sheetColumns.description].formattedValue ?? '';
+          languages[config.sheetColumns.description].formattedValue ?? '';
 
       final values = row.values
           .sublist(firstLanguageColumn, row.values.length)

--- a/lib/src/gsheet_to_arb.dart
+++ b/lib/src/gsheet_to_arb.dart
@@ -18,16 +18,10 @@ class GSheetToArb {
     Log.startTimeTracking();
 
     final gsheet = config.gsheet;
-    final auth = gsheet.auth;
     final documentId = gsheet.documentId;
 
     // import TranslationsDocument
-    final importer = GSheetImporter(
-      auth: auth, 
-      categoryPrefix: gsheet.categoryPrefix,
-      sheetColumns: SheetColumns(),
-      sheetRows: SheetRows(),
-    );
+    final importer = GSheetImporter(config: gsheet);
     final document = await importer.import(documentId);
 
     // Parse TranslationsDocument to ArbBundle

--- a/lib/src/gsheet_to_arb.dart
+++ b/lib/src/gsheet_to_arb.dart
@@ -22,8 +22,12 @@ class GSheetToArb {
     final documentId = gsheet.documentId;
 
     // import TranslationsDocument
-    final importer =
-        GSheetImporter(auth: auth, categoryPrefix: gsheet.categoryPrefix);
+    final importer = GSheetImporter(
+      auth: auth, 
+      categoryPrefix: gsheet.categoryPrefix,
+      sheetColumns: SheetColumns(),
+      sheetRows: SheetRows(),
+    );
     final document = await importer.import(documentId);
 
     // Parse TranslationsDocument to ArbBundle


### PR DESCRIPTION
Can now specify the index for where the column of `key`, `description` and `first_language_key` as well as  the rows for `header_row` and `first_translation_row`.

If these are not set in the config file we will fallback to the old default values so this change will compatible with older versions.

These configurations are also generated with the create-config command.

There is documentation on how to use it in the readme

