### PR TITLE
Fix parsing crashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@
 - the first column `key` contains either key name or category prefix
 - the second column `description` contains item description
 - all the following column (language codes e.g. `en`, `pl` etc.) contains traslation files
-- make sure spreadsheet contains only valid colums i.e. with langauge key value
+- will start parsing from the first language column and stop parsing on the last column or the first empty column, which ever comes first
 
 ### Values
 - Placeholder 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@
 - other rows
     - if rows start with the `category_prefix` value (`# ` default) all the following rows will use the category as a context (see: ARB context, and `add_context_prefix` parameter)
     - empty rows are ignored
+    - rows with an empty key column are ignored
 
 ### Columns
 

--- a/lib/src/gsheet/ghseet_importer.dart
+++ b/lib/src/gsheet/ghseet_importer.dart
@@ -82,8 +82,12 @@ class GSheetImporter {
     for (var column = firstLanguageColumn;
         column < headerValues.length;
         column++) {
-        final language = headerValues[column].formattedValue;
-        languages.add(language);
+      //Stop parsing on first empty language code
+      if(headerValues[column].formattedValue == null) {
+        break;
+      }
+      final language = headerValues[column].formattedValue;
+      languages.add(language);
     }
 
     // rows

--- a/lib/src/gsheet/ghseet_importer.dart
+++ b/lib/src/gsheet/ghseet_importer.dart
@@ -82,18 +82,24 @@ class GSheetImporter {
     for (var column = firstLanguageColumn;
         column < headerValues.length;
         column++) {
-      final language = headerValues[column].formattedValue;
-      languages.add(language);
+        final language = headerValues[column].formattedValue;
+        languages.add(language);
     }
 
     // rows
     for (var i = firstTranslationsRow; i < rows.length; i++) {
       var row = rows[i];
       var languages = row.values;
+
+      //Skip empty rows
+      if(languages == null) {
+        continue;
+      }
+
       var key = languages[_SheetColumns.key].formattedValue;
 
-      //Skip if empty row is found
-      if (key == null) {
+      //Skip rows with missing key value
+      if(key == null) {
         continue;
       }
 

--- a/lib/src/parser/translation_parser.dart
+++ b/lib/src/parser/translation_parser.dart
@@ -33,11 +33,24 @@ class TranslationParser {
     for (var item in document.items) {
       // for each language
       for (var index in iterables.range(0, document.languages.length)) {
-        final itemValue = item.values[index];
+        if(item.values.length != document.languages.length) {
+          print(item.values.toString());
+        }
+        
+        var itemValue;
+        //incase value does not exist
+        if(index < item.values.length) {
+          itemValue = item.values[index];
+        } else {
+          itemValue = '';
+        }
+        
         final itemPlaceholders = _findPlaceholders(itemValue);
 
         final builder = builders[index];
         final parser = parsers[index];
+
+
 
         // plural consume
         final status = parser.consume(ArbResource(item.key, itemValue,

--- a/lib/src/parser/translation_parser.dart
+++ b/lib/src/parser/translation_parser.dart
@@ -40,6 +40,10 @@ class TranslationParser {
         } else {
           itemValue = '';
         }
+
+        if(itemValue == '') {
+          print('WARNING: empty string in lang: '+ document.languages[index] + ', key: '+ item.key);
+        }
         
         final itemPlaceholders = _findPlaceholders(itemValue);
 

--- a/lib/src/parser/translation_parser.dart
+++ b/lib/src/parser/translation_parser.dart
@@ -7,6 +7,7 @@
 import 'dart:async';
 import 'package:gsheet_to_arb/src/arb/arb.dart';
 import 'package:gsheet_to_arb/src/translation_document.dart';
+import 'package:gsheet_to_arb/src/utils/log.dart';
 
 import 'package:quiver/iterables.dart' as iterables;
 import 'package:recase/recase.dart';
@@ -42,15 +43,13 @@ class TranslationParser {
         }
 
         if(itemValue == '') {
-          print('WARNING: empty string in lang: '+ document.languages[index] + ', key: '+ item.key);
+          Log.i('WARNING: empty string in lang: '+ document.languages[index] + ', key: '+ item.key);
         }
         
         final itemPlaceholders = _findPlaceholders(itemValue);
 
         final builder = builders[index];
         final parser = parsers[index];
-
-
 
         // plural consume
         final status = parser.consume(ArbResource(item.key, itemValue,

--- a/lib/src/parser/translation_parser.dart
+++ b/lib/src/parser/translation_parser.dart
@@ -33,10 +33,6 @@ class TranslationParser {
     for (var item in document.items) {
       // for each language
       for (var index in iterables.range(0, document.languages.length)) {
-        if(item.values.length != document.languages.length) {
-          print(item.values.toString());
-        }
-        
         var itemValue;
         //incase value does not exist
         if(index < item.values.length) {


### PR DESCRIPTION
- Will ignore empty rows without crashing,
- Will ignore rows with empty key value
- Fix crash if a translation value is missing for a language, now defaults to an empty string
- Print a warning to the console if an empty string is found when parsing