### PR TITLE
`intl` conditional dependency - compatibility with flutter 1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,29 @@
+## 0.1.9
+
+- `intl` conditional dependency (fixes compatibility with flutter_localizations on flutter 1.12.13) (thanks to [@jarekb123](https://github.com/jarekb123))
+
 ## 0.1.8
+
 - Update pubspec dependencies (thanks to [@jarekb123](https://github.com/jarekb123))
 
-
 ## 0.1.7
+
 - Readme fix
 
 ## 0.1.4
+
 - Fix problem with plurals generation
 
 ## 0.1.3
+
 - Documentation update
 
 ## 0.1.2
+
 - Add logging output
 
 ## 0.1.1
+
 - Add plurals
 - Fix create-config flag
 - Change configuration structure - moved to pubspec.yaml

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   args: ">=1.5.2 <2.0.0"
   dart_style: ">=1.3.3 <2.0.0"
-  intl: ">=0.16.1 <0.17.0"
+  intl: ">=0.16.0 <0.17.0"
   path: ">=1.6.4 <2.0.0"
   googleapis_auth: ^0.2.6
   googleapis: ^0.54.0


### PR DESCRIPTION
`flutter_localizations` from flutter sdk 1.12 depends on intl 0.16.0