### PR TITLE
updated dependency to remove conflicts

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   path: ">=1.6.4 <2.0.0"
   googleapis_auth: ^0.2.6
   googleapis: ^0.54.0
-  code_builder: ">=3.1.3 <3.3.0"
+  code_builder: ">=3.1.3 <3.4.0"
   intl_translation: "^0.17.10"
   json_annotation: "^3.0.1"
   file_utils: ">=0.1.1 <0.2.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   path: ">=1.6.4 <2.0.0"
   googleapis_auth: ^0.2.6
   googleapis: ^0.54.0
-  code_builder: ">=3.1.3 <3.4.0"
+  code_builder: "3.4.0"
   intl_translation: "^0.17.10"
   json_annotation: "^3.0.1"
   file_utils: ">=0.1.1 <0.2.0"


### PR DESCRIPTION
bloc_test 7.1.0 with new feature "seed" value depends on mockito 4.1.2. Mockito has conflicts with code_builder because it depends on version 3.4.0. I updated code_builder to remove conflicts 